### PR TITLE
swap priority of script hash prefixes

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -145,7 +145,7 @@ addNetwork({
   alias: 'mainnet',
   pubkeyhash: 35,
   privatekey: [176, 163], // 176 is Litecoin
-  scripthash: [8, 94],
+  scripthash: [94, 8],
   xpubkey: 0x0134406b,
   xprivkey: 0x01343c31,
   networkMagic: 0xfdc0a5f1,


### PR DESCRIPTION
default to using `e`/`f` rather than `4` on P2SH addresses

example transaction https://livenet.flocha.in/tx/cfb1b7b0f57283a078c6cbd9bf7baf9f688b454814a3e4199f9508b901db40c6

